### PR TITLE
reqs: bump outdated deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib==3.1.2
 simplejson==3.16.0
-scipy==1.4.1
+scipy==1.7.1
 numpy==1.18.1
 hmmlearn==0.2.2
 eyeD3==0.9.5


### PR DESCRIPTION
Otherwise it fails to build, relevant issue: https://github.com/scipy/scipy/issues/11611

```
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
```

I'm on latest software:

```
$ gfortran --version
GNU Fortran (GCC) 11.2.1 20210728 (Red Hat 11.2.1-1)
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

I would appreciate if you confirm if this is buildable with your tools (maybe slightly older fortran?)

Basically, just `pip install scipy==1.7.1` (sorry if pip cmd is wrong, I tried with `pipenv install scipy~=1.7`).

---

System-wide deps to make it build (in Fedora 34):

```shell
sudo dnf install \
  python3-devel \
  openblas-devel \
  lapack-devel \
  freetype-devel \
  atlas-devel
```